### PR TITLE
Remove HELICS_DISABLE_GIT_OPERATIONS

### DIFF
--- a/helics_apps-pip/setup.py
+++ b/helics_apps-pip/setup.py
@@ -34,7 +34,10 @@ DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/
 class HELICSBdistWheel(bdist_wheel):
     def get_tag(self):
         rv = super().get_tag()
-        return ("py2.py3", "none",) + rv[2:]
+        return (
+            "py2.py3",
+            "none",
+        ) + rv[2:]
 
 
 class HELICSCMakeBuild(build_ext):
@@ -78,7 +81,6 @@ class HELICSCMakeBuild(build_ext):
             extdir += os.path.sep
 
         cmake_args = [
-            "-DHELICS_DISABLE_GIT_OPERATIONS=OFF",
             "-DHELICS_ZMQ_SUBPROJECT=ON",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_INSTALL_PREFIX={}".format(extdir),


### PR DESCRIPTION
This bizarrely causes logging to fail. Adding `-DHELICS_DISABLE_GIT_OPERATIONS=OFF` (even though `OFF` is the default) 


```
   9   │ #pragma once
  10   │
  11   │ /* #undef HELICS_ENABLE_MPI_CORE */
  12   │ #define HELICS_ENABLE_ZMQ_CORE
  13   │ #define HELICS_ENABLE_TCP_CORE
  14   │ #define HELICS_ENABLE_IPC_CORE
  15   │ #define HELICS_ENABLE_UDP_CORE
  16   │ /* #undef HELICS_ENABLE_TEST_CORE */
  17   │ #define HELICS_ENABLE_INPROC_CORE
  18   │
  19   │
  20   │ /* #undef HELICS_ENABLE_LOGGING */
  21   │ /* #undef HELICS_ENABLE_TRACE_LOGGING */
  22   │ /* #undef HELICS_ENABLE_DEBUG_LOGGING */
  23   │ /* #undef HELICS_ENABLE_WEBSERVER */
  24   │
  25   │ /* #undef HELICS_DISABLE_ASIO */
  26   │
  27   │ /* #undef HELICS_USE_PICOSECOND_TIME */
  28   │
  29   │ #define HELICS_VERSION_MAJOR 3
  30   │ #define HELICS_VERSION_MINOR 1
  31   │ #define HELICS_VERSION_PATCH 0
  32   │ #define HELICS_VERSION 3.1.0
  33   │ #define HELICS_VERSION_BUILD ""
  34   │ #define HELICS_VERSION_STRING "3.1.0 (2021-11-24)"
  35   │ #define HELICS_DATE "2021-11-24"
  36   │ #define HELICS_COMPILER_VERSION "Unix Makefiles  Darwin-19.6.0:AppleClang-11.0.3.11030032"
  37   │ #define HELICS_BUILD_FLAGS_RELEASE " -O3 -DNDEBUG  $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>"
  38   │ #define HELICS_BUILD_FLAGS_DEBUG " -g  $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>"
  39   │ #define HELICS_BUILD_PROCESSOR "x86_64"
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Running `cmake` twice seems to solve the problem. 